### PR TITLE
Update Makefile_32.cpu CPU flags

### DIFF
--- a/arch/x86/Makefile_32.cpu
+++ b/arch/x86/Makefile_32.cpu
@@ -34,8 +34,8 @@ cflags-$(CONFIG_MVIAC7)		+= -march=i686
 cflags-$(CONFIG_MCORE2)		+= -march=i686 $(call tune,core2)
 cflags-$(CONFIG_MATOM)		+= $(call cc-option,-march=atom,$(call cc-option,-march=core2,-march=i686)) \
 	$(call cc-option,-mtune=atom,$(call cc-option,-mtune=generic))
-cflags-$(CONFIG_MSLM)		+= $(call cc-option,-march=slm,$(call cc-option,-march=core2,-march=i686)) \
-	$(call cc-option,-mtune=slm,$(call cc-option,-mtune=generic))
+cflags-$(CONFIG_MSLM) += $(call cc-option,-march=silvermont) \
+	$(call cc-option,-mtune=silvermont,$(call cc-option,-mtune=silvermont))
 
 # AMD Elan support
 cflags-$(CONFIG_MELAN)		+= -march=i486


### PR DESCRIPTION
Update CPU flags to silvermont ones using adapted changes of graysky2 patches. There is no need to edit the .config files, I keep the CONFIG_SLM, only changed the parameters.
